### PR TITLE
chore: fixed tautology in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">Dart Edge (Experimental)</h1>
-<p align="center">Run Dart on on the Edge - supporting Vercel & Cloudflare Workers (more coming soon).</p>
+<p align="center">Run Dart on the Edge - supporting Vercel & Cloudflare Workers (more coming soon).</p>
 
 <p align="center">
   <a href="https://github.com/invertase/melos#readme-badge"><img src="https://img.shields.io/badge/maintained%20with-melos-f700ff.svg?style=flat-square" alt="Melos" /></a>


### PR DESCRIPTION
I noticed a tautology error in the readme so I added a fix