### PR TITLE
fix(edge_runtime): patch location.href global

### DIFF
--- a/packages/edge_runtime/lib/edge_runtime.dart
+++ b/packages/edge_runtime/lib/edge_runtime.dart
@@ -36,5 +36,15 @@ export 'package:js_bindings/bindings/fetch.dart'
 
 /// This should be called before any other platform code is run.
 void setupRuntime() {
+  // Dart to JS looks for some context properties to determine whether some
+  // features are available. Uri.base checks whether window.location.href is
+  // available, so we patch it in here.
+  if (context['self']['location'] == null) {
+    context['self']['location'] = JsObject.jsify({
+      'href': '',
+    });
+  }
+
+  // Dart to JS assumes we're in a browser context, so we need to patch in.
   context['window'] ??= context['self'];
 }


### PR DESCRIPTION
Dart to JS checks for a `self.location.href` value to assert whether Uri.base is supported. We patch it in here since it is supported, but not available on v8 runtime.