### PR TITLE
docs: remove isolate from supabase client

### DIFF
--- a/docs/guides/shelf.mdx
+++ b/docs/guides/shelf.mdx
@@ -34,7 +34,7 @@ void main() {
     fetch: (request) async {
       final app = Router();
 
-      app.get('/', (request, String id) async {
+      app.get('/', (request) async {
         return Response.ok('Welcome to Dart Edge!');
       });
 
@@ -49,5 +49,3 @@ void main() {
 ```
 
 Alternatively, you could return a [`Pipeline`](https://pub.dev/documentation/shelf/latest/shelf/Pipeline-class.html) handler to apply middleware to your requests.
-
-

--- a/docs/platform/supabase/client.mdx
+++ b/docs/platform/supabase/client.mdx
@@ -21,40 +21,6 @@ Next, install the Dart Edge HTTP Client:
 dart pub add edge_http_client
 ```
 
-Next, install the `yet_another_json_isolate` package (more on this next...):
-
-```sh
-dart pub add yet_another_json_isolate
-```
-
-### Create an Isolate stub
-
-> Please note; this code will be extracted out at some point so this step will be easier.
-
-The Supabase client uses isolates to parse JSON off the main thread. This is not supported in Dart Edge, so we need to create a stub that will allow the client to run it in the main thread.
-
-```dart
-import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
-
-class EdgeIsolate implements YAJsonIsolate {
-  @override
-  Future decode(String json) {
-    return Future.value(jsonDecode(json));
-  }
-
-  @override
-  Future<void> dispose() async {}
-
-  @override
-  Future<String> encode(Object? json) {
-    return Future.value(jsonEncode(json));
-  }
-
-  @override
-  Future<void> initialize() async {}
-}
-```
-
 ## Usage
 
 Within your `lib/main` file, import the `supabase` package and create a new instance of the client:
@@ -69,7 +35,6 @@ void main() {
     'https://<your-project-id>.supabase.co',
     'your-anon-key',
     httpClient: EdgeHttpClient(),
-    isolate: EdgeIsolate(),
   );
 
   SupabaseFunctions(fetch: (request) async {


### PR DESCRIPTION
I've already removed the isolate part in the Supabase documentation [here](https://github.com/supabase/supabase/pull/13743). I've fixed the underlying issue in the isolate package, which needed the custom overriding.

Additionally I've removed the `id` in the shelf example, because there is no placeholder.