### PR TITLE
feat: Refactor Response class and add new initialization methods

### DIFF
--- a/packages/edge_runtime/lib/src/response.dart
+++ b/packages/edge_runtime/lib/src/response.dart
@@ -20,10 +20,14 @@ class Response implements Body {
 
   /// Creates a new [Response] object.
   /// The [body] can be a [String], [ByteBuffer] or [Uint8List].
+  ///
+  /// [status] is an HTTP status code and defaults to `200`.
+  /// [statusText] is a status message and defaults to `''`.
+  /// [headers] can be used to set HTTP headers, defaults to providing no headers.
   Response(
     Object? body, {
-    int status = 200,
-    String statusText = '',
+    int? status,
+    String? statusText,
     Headers? headers,
   }) : _delegate = interop.Response(
           convertBody(body),

--- a/packages/edge_runtime/lib/src/response.dart
+++ b/packages/edge_runtime/lib/src/response.dart
@@ -94,7 +94,10 @@ class Response implements Body {
         interop.ResponseInit(
           status: status,
           statusText: statusText,
-          headers: headers?.delegate ?? jsUndefined,
+          headers: headers?.delegate ??
+              Headers({
+                'Content-Type': 'application/json; charset=utf-8',
+              }),
         ),
       ),
     );

--- a/packages/edge_runtime/lib/src/response.dart
+++ b/packages/edge_runtime/lib/src/response.dart
@@ -9,51 +9,91 @@ import 'blob.dart';
 import 'body.dart';
 import 'form_data.dart';
 import 'headers.dart';
+import 'interop/headers.dart' as headers_interop;
 import 'interop/readable_stream.dart';
 import 'interop/utils_interop.dart';
-import 'interop/headers.dart' as headers_interop;
 
 class Response implements Body {
   final interop.Response _delegate;
 
   Response._(this._delegate);
 
+  /// Creates a new [Response] object.
+  /// The [body] can be a [String], [ByteBuffer] or [Uint8List].
   Response(
     Object? body, {
-    int? status,
-    String? statusText,
+    int status = 200,
+    String statusText = '',
     Headers? headers,
   }) : _delegate = interop.Response(
           convertBody(body),
           interop.ResponseInit(
-            status: status ?? 200,
-            statusText: statusText ?? '',
+            status: status,
+            statusText: statusText,
             headers: headers?.delegate ?? jsUndefined,
           ),
         );
 
+  /// Creates a new [Response] object with an error.
+  ///
+  /// See also https://developer.mozilla.org/en-US/docs/Web/API/Response/error.
   factory Response.error() {
     return Response._(interop.Response.error());
   }
 
+  /// Creates a new [Response] object with a redirect to the given [url].
+  ///
+  /// See also https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect.
   factory Response.redirect(Uri url, [int? status = 302]) {
     return Response._(
       interop.Response.redirect(url.toString(), status),
     );
   }
 
-  factory Response.json(
+  /// Creates a new [Response] object with a JS object as the body.
+  /// Recursively converts a JSON-like collection to JavaScript compatible representation.
+  /// It is recommended to use [Response.json] instead as it is more efficient.
+  ///
+  /// The data must be a [Map] or [Iterable], the contents of which are also deeply converted.
+  /// Maps are converted into JavaScript objects. Iterables are converted into arrays.
+  /// Strings, numbers, bools, and @JS() annotated objects are passed through unmodified.
+  /// Dart objects are also passed through unmodified, but their members aren't usable from JavaScript.
+  ///
+  /// Copied from [jsify].
+  factory Response.jsify(
     Object? data, {
-    int? status,
-    String? statusText,
+    int status = 200,
+    String statusText = '',
     Headers? headers,
   }) {
     return Response._(
       interop.Response.json(
         data != null ? jsify(data) : null,
         interop.ResponseInit(
-          status: status ?? 200,
-          statusText: statusText ?? '',
+          status: status,
+          statusText: statusText,
+          headers: headers?.delegate ?? jsUndefined,
+        ),
+      ),
+    );
+  }
+
+  /// Creates a new [Response] object with a JSON string as the body.
+  /// [data] is converted to a JSON string using [jsonEncode].
+  ///
+  /// If you are using a JS object as the body, use [Response.jsify] instead.
+  factory Response.json(
+    Object? data, {
+    int status = 200,
+    String statusText = '',
+    Headers? headers,
+  }) {
+    return Response._(
+      interop.Response(
+        data != null ? jsonEncode(data) : null,
+        interop.ResponseInit(
+          status: status,
+          statusText: statusText,
           headers: headers?.delegate ?? jsUndefined,
         ),
       ),

--- a/packages/edge_runtime/lib/src/response.dart
+++ b/packages/edge_runtime/lib/src/response.dart
@@ -50,16 +50,18 @@ class Response implements Body {
     );
   }
 
+  /// **Warning:** It is recommended to use [Response.json] instead
+  /// as this method is less efficient and the response data can become minified
+  /// if you enable minification in your build.
+  ///
   /// Creates a new [Response] object with a JS object as the body.
   /// Recursively converts a JSON-like collection to JavaScript compatible representation.
-  /// It is recommended to use [Response.json] instead as it is more efficient.
-  ///
   /// The data must be a [Map] or [Iterable], the contents of which are also deeply converted.
   /// Maps are converted into JavaScript objects. Iterables are converted into arrays.
   /// Strings, numbers, bools, and @JS() annotated objects are passed through unmodified.
   /// Dart objects are also passed through unmodified, but their members aren't usable from JavaScript.
   ///
-  /// Copied from [jsify].
+  /// *Copied from [jsify]*.
   factory Response.jsify(
     Object? data, {
     int status = 200,

--- a/packages/edge_runtime/lib/src/utils.dart
+++ b/packages/edge_runtime/lib/src/utils.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data' show ByteBuffer, Uint8List;
 
 Object? convertBody(Object? body) {
   return switch (body) {
-    String || Uint8List || ByteBuffer || null => body,
+    String() || Uint8List() || ByteBuffer() || null => body,
     _ => throw ArgumentError.value(
         body,
         'body',

--- a/packages/edge_runtime/lib/src/utils.dart
+++ b/packages/edge_runtime/lib/src/utils.dart
@@ -1,25 +1,12 @@
 import 'dart:typed_data' show ByteBuffer, Uint8List;
 
 Object? convertBody(Object? body) {
-  if (body == null) {
-    return null;
-  }
-
-  if (body is String) {
-    return body;
-  }
-
-  if (body is Uint8List) {
-    return body;
-  }
-
-  if (body is ByteBuffer) {
-    return body;
-  }
-
-  throw ArgumentError.value(
-    body,
-    'body',
-    'Body must be an nullable instance of [String], [ByteBuffer] or [Uint8List].',
-  );
+  return switch (body) {
+    String || Uint8List || ByteBuffer || null => body,
+    _ => throw ArgumentError.value(
+        body,
+        'body',
+        'Body must be a nullable instance of [String], [ByteBuffer] or [Uint8List].',
+      ),
+  };
 }

--- a/packages/edge_runtime/pubspec.yaml
+++ b/packages/edge_runtime/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/invertase/dart_edge/tree/main/packages/edge_runti
 version: 0.0.4+1
 
 environment:
-  sdk: ">=2.18.5 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   freezed_annotation: ^2.2.0


### PR DESCRIPTION
## Changes

- Add default response status and status text in the `Response` constructors
- Add `Response.jsify` method for initializing `Response` with a JS object as body
- Separate `Response.json` method from `Response.jsify` for initializing `Response` with a JSON-encodable object as body
- Add documentation for main the constructors of `Response`

## Motivation

`jsify` is subject to minification and has [somewhat bad performance](https://api.dart.dev/stable/2.19.6/dart-js_util/jsify.html). When using `dart compile` with minification enabled, the response json gets minified (after a certain depth AFAIK). It should not be the case. The new `Response.json` behaves simlarly from the previous implementation except that it doesn't minify as it uses `json.encode`. Renamed the previous implementation to `Response.jsify` as it could still be useful for some cases.