### PR TITLE
docs: missing `supabase start` step from supabase sample

### DIFF
--- a/examples/supabase-edge-functions/README.md
+++ b/examples/supabase-edge-functions/README.md
@@ -10,6 +10,14 @@ Install the dependencies:
 dart pub get
 ```
 
+Pull supabase images:
+
+*Note that this step is only required once, make sure you have [Docker](https://docs.docker.com/engine/install/) installed.*
+
+```bash
+supabase start
+```
+
 Start the application via Dart Edge CLU & the [`supabase` CLI](https://supabase.com/docs/guides/cli):
 
 ```bash


### PR DESCRIPTION
Added `supabase start` to supabase sample README along with Docker requirement. 