### PR TITLE
Updates the Supabase template to include an default edge.yaml file.

### DIFF
--- a/bricks/supabase_functions/__brick__/edge.yaml
+++ b/bricks/supabase_functions/__brick__/edge.yaml
@@ -1,0 +1,2 @@
+supabase:
+  project_path: './supabase'

--- a/bricks/supabase_functions/__brick__/pubspec.yaml
+++ b/bricks/supabase_functions/__brick__/pubspec.yaml
@@ -4,10 +4,10 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=2.18.5 <3.0.0"
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
-  edge: ^0.0.5
+  edge: ^0.0.7
   supabase_functions: ^0.0.1
 
 dev_dependencies:

--- a/docs/platform/supabase/config.mdx
+++ b/docs/platform/supabase/config.mdx
@@ -9,17 +9,17 @@ The following Supabase configuration options are supported via the `edge.yaml` f
 ```yaml
 supabase:
   # The path to root of where your Supabase project exists.
-  projectPath: '.'
+  project_path: '.'
   # An object of functions and their entrypoints to build.
   # This is used if you have multiple Supabase function entrypoints.
   functions:
     dart_edge: 'lib/main.dart'
   # The compiler optimization level to use for development builds.
-  devCompilerLevel: 01
+  dev_compiler_l_evel: 01
   # The compiler optimization level to use for production builds.
-  prodCompilerLevel: 04
+  prod_compiler_level: 04
   # Whether to exit the development watch process when a build fails.
-  exitWatchOnFailure: false
+  exit_watch_on_failure: false
 ```
 
 ## Multiple entrypoints


### PR DESCRIPTION
Currently the default Supabase project doesn't include an edge.yaml file by default, and the developers have to create it manually. This PR adds a default edge.yaml file. Also, the configuration key on the edge.yaml file didn't work with camel case, but instead works with snake case, so updated the docs. 

Fixes https://github.com/invertase/dart_edge/issues/36, https://github.com/invertase/dart_edge/issues/59, https://github.com/invertase/dart_edge/issues/58, https://github.com/invertase/dart_edge/issues/52